### PR TITLE
Add AccessStaticPropertyWithinModelContextRule and create Yii config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use this extension, require it in [Composer](https://getcomposer.org/):
 composer require --dev slam/phpstan-extensions
 ```
 
-And include slam-rules.neon in your project's PHPStan config:
+And include `slam-rules.neon` in your project's PHPStan config:
 
 ```yaml
 includes:
@@ -36,3 +36,20 @@ includes:
     1. `@covers`
     1. `@coversDefaultClass`
     1. `@uses`
+1.  `SlamPhpStan\AccessStaticPropertyWithinModelContextRule`: inhibit the access to static attributes of a class within
+classes that extend or implement a certain class/interface, useful to prohibit usage of singletons in models
+
+## Yii-specific config
+
+A `yii-rules.neon` config is present for Yii projects:
+
+```yaml
+includes:
+    - vendor/slam/phpstan-extensions/conf/yii-rules.neon
+```
+
+With the following configurations:
+
+1. `SlamPhpStan\AccessStaticPropertyWithinModelContextRule` to deny the usage of `yii\BaseYii` static variables like
+`$app` in models implementing `yii\db\ActiveRecordInterface`: accessing to singletons in models is considered an
+anti-pattern

--- a/conf/yii-rules.neon
+++ b/conf/yii-rules.neon
@@ -1,0 +1,8 @@
+services:
+    -
+        class: SlamPhpStan\AccessStaticPropertyWithinModelContextRule
+        tags:
+            - phpstan.rules.rule
+        arguments:
+            modelBaseClassOrInterface: yii\db\ActiveRecordInterface
+            singletonAccessor: yii\BaseYii

--- a/lib/AccessStaticPropertyWithinModelContextRule.php
+++ b/lib/AccessStaticPropertyWithinModelContextRule.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlamPhpStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Rules\Rule;
+
+final class AccessStaticPropertyWithinModelContextRule implements Rule
+{
+    /**
+     * @var Broker
+     */
+    private $broker;
+
+    /**
+     * @var string
+     */
+    private $modelBaseClassOrInterface;
+
+    /**
+     * @var string
+     */
+    private $singletonAccessor;
+
+    public function __construct(Broker $broker, string $modelBaseClassOrInterface, string $singletonAccessor)
+    {
+        $this->broker                    = $broker;
+        $this->modelBaseClassOrInterface = $modelBaseClassOrInterface;
+        $this->singletonAccessor         = $singletonAccessor;
+    }
+
+    public function getNodeType(): string
+    {
+        return StaticPropertyFetch::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\StaticPropertyFetch $node
+     * @param \PHPStan\Analyser\Scope                  $scope
+     *
+     * @return string[] errors
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->class instanceof Node\Name || ! $node->name instanceof Node\VarLikeIdentifier) {
+            return [];
+        }
+
+        if (! $scope->isInClass()) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (null === $classReflection || ! $classReflection->isSubclassOf($this->modelBaseClassOrInterface)) {
+            return [];
+        }
+
+        $baseYiiClassName = (string) $node->class;
+        if (! $this->broker->hasClass($baseYiiClassName)) {
+            return [];
+        }
+
+        $baseYiiClass = $this->broker->getClass($baseYiiClassName);
+        if ($baseYiiClassName !== $this->singletonAccessor && ! $baseYiiClass->isSubclassOf($this->singletonAccessor)) {
+            return [];
+        }
+
+        return [\sprintf('Class %s extends or implements %s and uses %s::$%s: in a model accessing to a singleton is considered an anti-pattern',
+            $classReflection->getName(),
+            $this->modelBaseClassOrInterface,
+            $this->singletonAccessor,
+            (string) $node->name
+        )];
+    }
+}

--- a/lib/AccessStaticPropertyWithinModelContextRule.php
+++ b/lib/AccessStaticPropertyWithinModelContextRule.php
@@ -70,8 +70,11 @@ final class AccessStaticPropertyWithinModelContextRule implements Rule
             return [];
         }
 
-        return [\sprintf('Class %s extends or implements %s and uses %s::$%s: in a model accessing to a singleton is considered an anti-pattern',
-            $classReflection->getName(),
+        $modelBaseClassOrInterface = $this->broker->getClass($this->modelBaseClassOrInterface);
+
+        return [\sprintf('Class %s %s %s and uses %s::$%s: in a model accessing to a singleton is considered an anti-pattern',
+            $classReflection->getDisplayName(),
+            $modelBaseClassOrInterface->isInterface() ? 'implements' : 'extends',
             $this->modelBaseClassOrInterface,
             $this->singletonAccessor,
             (string) $node->name

--- a/lib/AccessStaticPropertyWithinModelContextRule.php
+++ b/lib/AccessStaticPropertyWithinModelContextRule.php
@@ -56,11 +56,11 @@ final class AccessStaticPropertyWithinModelContextRule implements Rule
         }
 
         $classReflection = $scope->getClassReflection();
-        if (null === $classReflection || ! $classReflection->isSubclassOf($this->modelBaseClassOrInterface)) {
+        if (! $classReflection->isSubclassOf($this->modelBaseClassOrInterface)) {
             return [];
         }
 
-        $baseYiiClassName = (string) $node->class;
+        $baseYiiClassName = $scope->resolveName($node->class);
         if (! $this->broker->hasClass($baseYiiClassName)) {
             return [];
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,3 +11,12 @@ parameters:
         - tests/
     excludes_analyse:
         - tests/TestAsset/
+
+services:
+	scopeIsInClass:
+		class: PHPStan\Internal\ScopeIsInClassTypeSpecifyingExtension
+		arguments:
+			isInMethodName: isInClass
+			removeNullMethodName: getClassReflection
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension

--- a/tests/AccessStaticPropertyWithinModelContextRuleTest.php
+++ b/tests/AccessStaticPropertyWithinModelContextRuleTest.php
@@ -50,7 +50,7 @@ final class AccessStaticPropertyWithinModelContextRuleTest extends RuleTestCase
             ],
             [
                 [
-                    \sprintf('Class %s extends or implements %s and uses %s::$app: in a model accessing to a singleton is considered an anti-pattern',
+                    \sprintf('Class %s implements %s and uses %s::$app: in a model accessing to a singleton is considered an anti-pattern',
                         TestAsset\ModelAccessingYiiAppSingletons::class,
                         $this->modelBaseClassOrInterface,
                         $this->singletonAccessor
@@ -58,7 +58,7 @@ final class AccessStaticPropertyWithinModelContextRuleTest extends RuleTestCase
                     8,
                 ],
                 [
-                    \sprintf('Class %s extends or implements %s and uses %s::$app: in a model accessing to a singleton is considered an anti-pattern',
+                    \sprintf('Class %s implements %s and uses %s::$app: in a model accessing to a singleton is considered an anti-pattern',
                         TestAsset\ModelAccessingYiiAppSingletons::class,
                         $this->modelBaseClassOrInterface,
                         $this->singletonAccessor

--- a/tests/AccessStaticPropertyWithinModelContextRuleTest.php
+++ b/tests/AccessStaticPropertyWithinModelContextRuleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlamPhpStan\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use SlamPhpStan\AccessStaticPropertyWithinModelContextRule;
+
+/**
+ * @covers \SlamPhpStan\AccessStaticPropertyWithinModelContextRule
+ */
+final class AccessStaticPropertyWithinModelContextRuleTest extends RuleTestCase
+{
+    /**
+     * @var string
+     */
+    private $modelBaseClassOrInterface;
+
+    /**
+     * @var string
+     */
+    private $singletonAccessor;
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        $this->modelBaseClassOrInterface = TestAsset\YiiAlikeActiveRecordInterface::class;
+        $this->singletonAccessor         = TestAsset\YiiAlikeBaseYii::class;
+
+        parent::__construct($name, $data, $dataName);
+    }
+
+    protected function getRule(): Rule
+    {
+        $broker = $this->createBroker();
+
+        return new AccessStaticPropertyWithinModelContextRule(
+            $broker,
+            $this->modelBaseClassOrInterface,
+            $this->singletonAccessor
+        );
+    }
+
+    public function testClassConstant()
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/TestAsset/AccessStaticPropertyWithinModelContextRule.php',
+            ],
+            [
+                [
+                    \sprintf('Class %s extends or implements %s and uses %s::$app: in a model accessing to a singleton is considered an anti-pattern',
+                        TestAsset\ModelAccessingYiiAppSingletons::class,
+                        $this->modelBaseClassOrInterface,
+                        $this->singletonAccessor
+                    ),
+                    8,
+                ],
+                [
+                    \sprintf('Class %s extends or implements %s and uses %s::$app: in a model accessing to a singleton is considered an anti-pattern',
+                        TestAsset\ModelAccessingYiiAppSingletons::class,
+                        $this->modelBaseClassOrInterface,
+                        $this->singletonAccessor
+                    ),
+                    10,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/AccessStaticPropertyWithinModelContextRuleTest.php
+++ b/tests/AccessStaticPropertyWithinModelContextRuleTest.php
@@ -42,7 +42,7 @@ final class AccessStaticPropertyWithinModelContextRuleTest extends RuleTestCase
         );
     }
 
-    public function testClassConstant()
+    public function testRule()
     {
         $this->analyse(
             [

--- a/tests/TestAsset/AccessStaticPropertyWithinModelContextRule.php
+++ b/tests/TestAsset/AccessStaticPropertyWithinModelContextRule.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SlamPhpStan\Tests\TestAsset;
+
+class ModelAccessingYiiAppSingletons implements YiiAlikeActiveRecordInterface {
+    public function foo() {
+        // \BaseYii::$app
+        YiiAlikeBaseYii::$app;
+        // Yii::$app
+        AnyOtherClassExtendingBaseYii::$app;
+        AnyOtherClass::$app;
+        $var = 'app';
+        AnyOtherClass::$$var;
+        NonExistingClass::$app;
+    }
+}
+
+class AnyOtherClass {
+    public static $app;
+
+    public function foo() {
+        // \BaseYii::$app
+        YiiAlikeBaseYii::$app;
+        // Yii::$app
+        AnyOtherClassExtendingBaseYii::$app;
+        self::$app;
+    }
+}
+
+trait YiiAppSingletonCallRuleTrait {
+    public function foo() {
+        // \BaseYii::$app
+        YiiAlikeBaseYii::$app;
+        // Yii::$app
+        AnyOtherClassExtendingBaseYii::$app;
+        AnyOtherClass::$app;
+    }
+}
+
+function YiiAppSingletonCallRuleFunction() {
+    // \BaseYii::$app
+    YiiAlikeBaseYii::$app;
+    // Yii::$app
+    AnyOtherClassExtendingBaseYii::$app;
+    AnyOtherClass::$app;
+}
+
+// \BaseYii::$app
+YiiAlikeBaseYii::$app;
+// Yii::$app
+AnyOtherClassExtendingBaseYii::$app;
+AnyOtherClass::$app;
+
+interface YiiAlikeActiveRecordInterface {}
+
+class YiiAlikeBaseYii {
+    public static $app;
+}
+
+class AnyOtherClassExtendingBaseYii extends YiiAlikeBaseYii {}


### PR DESCRIPTION
The basic idea is to prohibit access to singletons in models  (at least), which should be considered an anti-pattern. Example:

```php
class User extends ActiveRecord
{
    public function addToCart(Product $product)
    {
        \Yii::$app->session->set('products', [$product->id]);
    }
}
```
PHPStan will report:
```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   User.php                                                                                                                                                     
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------
  5      Class User extends or implements yii\db\ActiveRecordInterface and uses yii\BaseYii::$app: in a model accessing to a singleton is considered an anti-pattern  
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------
```
Default configuration is to prohibit access to any `yii\BaseYii` public static variables within classes implementing `yii\db\ActiveRecordInterface`.

Any idea or review is welcome, /cc @samdark (Yii2) and @akondas + @marmichalski ([proget-hq/phpstan-yii2](https://github.com/proget-hq/phpstan-yii2))