### PR TITLE
use special code for backslash

### DIFF
--- a/lib/StringToClassRule.php
+++ b/lib/StringToClassRule.php
@@ -37,7 +37,7 @@ final class StringToClassRule implements Rule
             $className = \substr($className, 1);
         }
         $messages  = [];
-        if (! \preg_match('/^\\w.+\\w$/u', $className)) {
+        if (! \preg_match('/^\x5c\w.+\x5c\w$/u', $className)) {
             return $messages;
         }
         if (! $this->broker->hasClass($className)) {


### PR DESCRIPTION
`\\w` in PHP is the same as `\w`
to find backslash we need to use either `\\\\`, or `\x5c`. I prefer the second one, since it's more explicit