### PR TITLE
StringToClassRule: Add option to require strict casing

### DIFF
--- a/conf/slam-rules.neon
+++ b/conf/slam-rules.neon
@@ -1,3 +1,12 @@
+parameters:
+    stringToClassRule:
+        strictCasing: false
+
+parametersSchema:
+    stringToClassRule: structure([
+        strictCasing: bool()
+    ])
+
 services:
     -
         class: SlamPhpStan\ClassNotationRule
@@ -15,6 +24,8 @@ services:
         class: SlamPhpStan\StringToClassRule
         tags:
             - phpstan.rules.rule
+        arguments:
+            strictCasing: %stringToClassRule.strictCasing%
     -
         class: SlamPhpStan\UnusedVariableRule
         tags:

--- a/lib/StringToClassRule.php
+++ b/lib/StringToClassRule.php
@@ -16,10 +16,12 @@ use PHPStan\Rules\Rule;
 final class StringToClassRule implements Rule
 {
     private Broker $broker;
+    private bool $strictCasing;
 
-    public function __construct(Broker $broker)
+    public function __construct(Broker $broker, bool $strictCasing)
     {
         $this->broker = $broker;
+        $this->strictCasing = $strictCasing;
     }
 
     public function getNodeType(): string
@@ -45,7 +47,7 @@ final class StringToClassRule implements Rule
         }
 
         $classRef = $this->broker->getClass($className)->getNativeReflection();
-        if ($classRef->isInternal() && $classRef->getName() !== $className) {
+        if (($classRef->isInternal() || $this->strictCasing) && $classRef->getName() !== $className) {
             return $messages;
         }
 


### PR DESCRIPTION
My use case: I have some instances of the very simple `'wkt'` string and an old school, non-namespaced library declaring a `\WKT` class. This results in multiple false positives.

I disabled this option by default for backwards compatibility. Another option would be to not make it configurable and require strict casing for all classes, not only internal classes.