### PR TITLE
UnusedVariableRule: detect variable usage in `compact()` calls

### DIFF
--- a/tests/TestAsset/UnusedVariableRule/fixture.php
+++ b/tests/TestAsset/UnusedVariableRule/fixture.php
@@ -75,6 +75,9 @@ function foo($ref)
 
     $_SESSION = ['var19' => 1];
     $GLOBALS['foo'] = 'bar';
+
+    $usedInCompact = 'value';
+    compact('usedInCompact');
 }
 
 class Test
@@ -96,6 +99,9 @@ class Test
             $this->key = 1;
             $this->key2();
         }
+
+        $usedInCompact = 'value';
+        compact('usedInCompact');
     }
 }
 

--- a/tests/TestAsset/UnusedVariableRule/fixture.php
+++ b/tests/TestAsset/UnusedVariableRule/fixture.php
@@ -80,6 +80,15 @@ function foo($ref)
     compact('usedInCompact');
 }
 
+function bar()
+{
+    $alsoUsedInCompact = 'value';
+
+    if ($alsoUsedInCompact) {
+        compact('alsoUsedInCompact');
+    }
+}
+
 class Test
 {
     function foo(array $numVals)

--- a/tests/UnusedVariableRuleTest.php
+++ b/tests/UnusedVariableRuleTest.php
@@ -17,7 +17,9 @@ final class UnusedVariableRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new UnusedVariableRule();
+        $broker = $this->createBroker();
+
+        return new UnusedVariableRule($broker);
     }
 
     public function testUnusedVariable(): void
@@ -36,16 +38,8 @@ final class UnusedVariableRuleTest extends RuleTestCase
                     49,
                 ],
                 [
-                    'Function foo() has an unused variable $usedInCompact.',
-                    79,
-                ],
-                [
                     'Closure function has an unused variable $var5bis.',
                     27,
-                ],
-                [
-                    'Function foo() has an unused variable $usedInCompact.',
-                    103,
                 ],
             ]
         );

--- a/tests/UnusedVariableRuleTest.php
+++ b/tests/UnusedVariableRuleTest.php
@@ -36,8 +36,16 @@ final class UnusedVariableRuleTest extends RuleTestCase
                     49,
                 ],
                 [
+                    'Function foo() has an unused variable $usedInCompact.',
+                    79,
+                ],
+                [
                     'Closure function has an unused variable $var5bis.',
                     27,
+                ],
+                [
+                    'Function foo() has an unused variable $usedInCompact.',
+                    103,
                 ],
             ]
         );


### PR DESCRIPTION
## Summary
This adds support for detecting usage of variables in string arguments to the compact function.

I adapted the test cases and also ran it in big (private) project, where I recently added this rule: all of the false reported unused variables attributed to re-use in compact() were fixed with this patch.

### Notes
The first commit shows how they're still reported and the errors disappear with the 2nd commit.

### Links
- Fixes #14