### PR TITLE
Add missing identifiers

### DIFF
--- a/lib/PhpUnitFqcnAnnotationRule.php
+++ b/lib/PhpUnitFqcnAnnotationRule.php
@@ -61,7 +61,7 @@ final class PhpUnitFqcnAnnotationRule implements Rule
                 continue;
             }
             if (! $this->broker->hasClass($matches['className'])) {
-                $messages[] = RuleErrorBuilder::message(\sprintf('Class %s does not exist.', $matches['className']))->line($docComment->getStartLine() + $lineNumber)->build();
+                $messages[] = RuleErrorBuilder::message(\sprintf('Class %s does not exist.', $matches['className']))->identifier('phpunit.annotationClassNotFound')->line($docComment->getStartLine() + $lineNumber)->build();
             }
         }
 

--- a/lib/UnusedVariableRule.php
+++ b/lib/UnusedVariableRule.php
@@ -77,7 +77,7 @@ final class UnusedVariableRule implements Rule
                         ? \sprintf('Function %s()', $node->name)
                         : 'Closure function',
                     $varName
-                ))->line($var->getAttribute('startLine'))->build();
+                ))->identifier('variable.unused')->line($var->getAttribute('startLine'))->build();
             }
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43,7 +43,7 @@ parameters:
 			path: lib/UnusedVariableRule.php
 
 		-
-			message: '#^Parameter \#1 \$line of method PHPStan\\Rules\\RuleErrorBuilder\<PHPStan\\Rules\\RuleError\>\:\:line\(\) expects int, mixed given\.$#'
+			message: '#^Parameter \#1 \$line of method PHPStan\\Rules\\RuleErrorBuilder\<PHPStan\\Rules\\IdentifierRuleError\>\:\:line\(\) expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: lib/UnusedVariableRule.php


### PR DESCRIPTION
Although identifiers are optional for phpstan, I use bladestan and when such an error is triggers, it _requires_ those errors having identifiers. And I think they're the way to go/good practice, anyway.